### PR TITLE
Fix integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,12 +9,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        php: ['8.1', '8.2']
-        dependency-version: [prefer-lowest, prefer-stable]
-
-    name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
+    name: Integration Test
 
     steps:
       - name: Checkout
@@ -23,12 +18,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.2'
           tools: composer:v2
           coverage: none
 
       - name: Install Dependencies
-        run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+        run: composer update --prefer-stable --no-interaction --no-progress --ansi
 
       - name: Run Test Cases
         run: composer run test:integration

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -54,5 +54,7 @@ function result(array $data, int $status = 200): Result
 
 function integrationTestEnabled(): bool
 {
-    return getenv('INTEGRATION_TEST_ENABLED') === '1';
+    $value = getenv('INTEGRATION_TEST_ENABLED');
+
+    return filter_var($value, FILTER_VALIDATE_BOOLEAN);
 }


### PR DESCRIPTION
The unit tests have already been comprehensively covered against PHP 8.1 and PHP 8.2. The integration test is primarily focused on validating the SDK's compatibility with remote services. Therefore, it seems reasonable to consider removing the matrix from this test, as it may no longer be necessary.

On the other hand, the function `integrationTestEnabled` is robustly enhanced with boolean filter to handle the truthy value like `"true"` and `"1"`.