### PR TITLE
Supports configure HTTP client

### DIFF
--- a/src/MnsClient.php
+++ b/src/MnsClient.php
@@ -19,6 +19,13 @@ use Psr\Http\Message\ResponseInterface;
 final class MnsClient
 {
     /**
+     * The request options.
+     *
+     * @var array<string, mixed>
+     */
+    private array $config = [];
+
+    /**
      * The signature builder.
      */
     private BuildsSignature $signature;
@@ -73,6 +80,18 @@ final class MnsClient
     public function accessKeySecret(): string
     {
         return $this->accessKeySecret;
+    }
+
+    /**
+     * Configure request options.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function configure(array $config): self
+    {
+        $this->config = $config;
+
+        return $this;
     }
 
     /**
@@ -198,11 +217,24 @@ final class MnsClient
      */
     private function client(): Client
     {
-        return new Client([
+        return new Client([...$this->getConfiguration(), ...[
             'base_uri' => $this->endpoint,
-            'timeout' => 30.0,
             'handler' => $this->createHandler(),
-        ]);
+        ]]);
+    }
+
+    /**
+     * Get configuration for Guzzle client.
+     *
+     * @return array<string, mixed>
+     */
+    private function getConfiguration(): array
+    {
+        $default = [
+            'timeout' => 60.0,
+        ];
+
+        return [...$default, ...$this->config];
     }
 
     /**

--- a/tests/MnsClientTest.php
+++ b/tests/MnsClientTest.php
@@ -10,3 +10,11 @@ test('request has authorization header', function () {
     $mns->get('/');
     $mns->assertSent(fn ($request) => $request->hasHeader('Authorization') && $request->getHeaderLine('Authorization') === 'MNS key:foo');
 });
+
+test('configures request options', function () {
+    $mns = new MnsClient('https://123456789101112.mns.cn-hangzhou.aliyuncs.com', 'key', 'secret');
+    $mns->configure(['headers' => ['X-Foo' => 'Bar']]);
+    $mns->fake();
+    $mns->get('/');
+    $mns->assertSent(fn ($request) => $request->getHeaderLine('X-Foo') === 'Bar');
+});


### PR DESCRIPTION
The PR gives the ability to configure Guzzle request options; developers could easily customize directly to the client to suit their needs with only a 60-second default timeout included. Please be aware that the API `receiveMessage` and `batchReceiveMessage` could take up to 30 seconds to complete.