### PR TITLE
Skip open service test

### DIFF
--- a/tests/Integration/Versions/V20150606/ServiceTest.php
+++ b/tests/Integration/Versions/V20150606/ServiceTest.php
@@ -12,4 +12,4 @@ test('open service', function () {
     $result = $this->service->openService();
     expect($result->successful())->toBeTrue()
         ->and($result->orderId())->toBeString()->not->toBeEmpty();
-});
+})->skip();


### PR DESCRIPTION
The test cases([#1](https://github.com/dew-serverless/mns-php/actions/runs/7343071153) and [#2](https://github.com/dew-serverless/mns-php/actions/runs/7352397980)) have failed the last two days. The MNS service would no longer allow duplicate activations.

As my observation, the service activation contains some checks like identity verification(Mainland China), account payment completion(International), and risk detection. Even though we could get past all the checkings, the API could be completed successfully only once with a new account due to the changes.

Instead of maintaining test cases of the service activation API, it’s wise to focus on the queue and topic management, so let’s simply skip the test.